### PR TITLE
pom 变量问题

### DIFF
--- a/src/com/github/restful/tool/utils/RestUtil.java
+++ b/src/com/github/restful/tool/utils/RestUtil.java
@@ -14,11 +14,14 @@ import cn.hutool.core.util.ReUtil;
 import com.github.restful.tool.beans.Request;
 import com.github.restful.tool.utils.scanner.JaxrsHelper;
 import com.github.restful.tool.utils.scanner.SpringHelper;
-import com.intellij.lang.jvm.annotation.*;
+import com.intellij.lang.jvm.annotation.JvmAnnotationArrayValue;
+import com.intellij.lang.jvm.annotation.JvmAnnotationAttributeValue;
+import com.intellij.lang.jvm.annotation.JvmAnnotationClassValue;
+import com.intellij.lang.jvm.annotation.JvmAnnotationConstantValue;
+import com.intellij.lang.jvm.annotation.JvmAnnotationEnumFieldValue;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.impl.scopes.ModuleWithDependenciesScope;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiAnnotation;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiExpression;
@@ -114,21 +117,10 @@ public class RestUtil {
             if (contextPath != null && (mavenProp = ReUtil.getGroup0(mavenPropReg, contextPath)) != null) {
                 Document pomDoc = getModulePomFile(((ModuleWithDependenciesScope) scope).getModule());
                 if (pomDoc != null) {
-                    Element properties = pomDoc.getRootElement().element("properties");
-                    if (properties != null) {
-                        Element propItemElement = properties.element(
-                                mavenProp.substring(mavenProp.indexOf("@") + 1, mavenProp.lastIndexOf("@"))
-                        );
-                        if (propItemElement != null) {
-                            String name = propItemElement.getData().toString().trim();
-                            mavenProp = getPomFileProperties(properties, name);
-                            // 如果<properties>找不到则到根标签<project>寻找
-                            mavenProp = getPomFileProject(pomDoc.getRootElement(), mavenProp);
-                            if (StringUtil.isEmptyOrSpaces(mavenProp)) {
-                                return null;
-                            }
-                        }
-                    }
+                    mavenProp = replaceItem(pomDoc,
+                            "${" + mavenProp.substring(
+                                    mavenProp.indexOf("@") + 1, mavenProp.lastIndexOf("@")
+                            ) + "}");
                 }
                 contextPath = ReUtil.replaceAll(contextPath, mavenPropReg, mavenProp);
             }
@@ -152,75 +144,90 @@ public class RestUtil {
     }
 
     /**
+     * 从pom中替换变量
+     *
+     * @param pomDoc pom
+     * @param substring 变量 ${xxx}
+     */
+    private static String replaceItem(Document pomDoc, String substring) {
+        @Language("RegExp") final String propReg = "\\$\\{[A-Za-z0-9.:-]+}";
+        for (String itemName : ReUtil.findAll(propReg, substring, 0)) {
+            substring = getPomFileProject(pomDoc, itemName);
+            if (substring.startsWith("${")) {
+                substring = getPomFileProperties(pomDoc, itemName);
+            }
+        }
+        return substring;
+    }
+
+    /**
      * 获取properties-element的值
      *
-     * @param element element
+     * @param pomDoc pomDoc
      * @param name    name
      * @return value
      */
     @NotNull
-    private static String getPomFileProperties(@Nullable Element element, String name) {
+    private static String getPomFileProperties(@Nullable Document pomDoc, String name) {
         // maven element 的变量格式：${java.version}
         @Language("RegExp") final String propReg = "\\$\\{[A-Za-z0-9.:-]+}";
         if (name == null) {
             return "";
         }
+        Element element = pomDoc.getRootElement().element("properties");
         if (element == null) {
-            return "";
+            return name;
         }
-        String response = name;
-        for (String nameItem : ReUtil.findAll(propReg, response, 0)) {
-            Element itemElement = element.element(nameItem.substring(
-                    nameItem.indexOf("{") + 1,
-                    nameItem.indexOf("}")
-            ));
-            if (itemElement != null) {
-                String itemResult = itemElement.getData().toString().trim();
-                for (String itemName : ReUtil.findAll(propReg, itemResult, 0)) {
-                    itemResult = itemResult.replace(itemName, getPomFileProperties(element, itemName));
-                }
-                response = response.replace(nameItem, itemResult);
+        Element itemElement = element.element(name.substring(
+                name.indexOf("{") + 1,
+                name.indexOf("}")
+        ));
+        if (itemElement != null) {
+            String itemResult = itemElement.getData().toString().trim();
+            for (String itemName : ReUtil.findAll(propReg, itemResult, 0)) {
+                itemResult = itemResult.replace(itemName, replaceItem(pomDoc, itemName));
             }
+            name = itemResult;
         }
-        return response;
+        return name;
     }
 
     /**
      * 获取project-element的值
      *
-     * @param element element
+     * @param pomDoc pomDoc
      * @param name    name
      * @return value
      */
     @NotNull
-    private static String getPomFileProject(@Nullable Element element, String name) {
+    private static String getPomFileProject(@Nullable Document pomDoc, String name) {
         // maven element 的变量格式：${project.version}
         @Language("RegExp") final String propReg = "\\$\\{[A-Za-z0-9.:-]+}";
         if (name == null) {
             return "";
         }
+        Element element = pomDoc.getRootElement();
         if (element == null) {
-            return "";
+            return name;
         }
-        String response = name;
-        for (String nameItem : ReUtil.findAll(propReg, response, 0)) {
-            String elementName = nameItem.substring(
-                    nameItem.indexOf("{") + 1,
-                    nameItem.indexOf("}")
-            );
-            if (elementName.toLowerCase().startsWith("project.")) {
-                elementName = elementName.substring(elementName.indexOf(".") + 1);
-            }
-            Element itemElement = element.element(elementName);
-            if (itemElement != null) {
-                String itemResult = itemElement.getData().toString().trim();
-                for (String itemName : ReUtil.findAll(propReg, itemResult, 0)) {
-                    itemResult = itemResult.replace(itemName, getPomFileProject(element, itemName));
-                }
-                response = response.replace(nameItem, itemResult);
+        String elementName = name.substring(
+                name.indexOf("{") + 1,
+                name.indexOf("}")
+        );
+        Element currentElement = element;
+        String[] path = elementName.split("\\.");
+        for (int i = 1; i < path.length; i++) {
+            currentElement = currentElement.element(path[i]);
+            if (currentElement == null) {
+                return name;
             }
         }
-        return response;
+        String itemResult = currentElement.getData().toString().trim();
+        for (String itemName : ReUtil.findAll(propReg, itemResult, 0)) {
+            itemResult = itemResult.replace(itemName, replaceItem(pomDoc, itemName));
+        }
+        name = itemResult;
+        return name;
     }
 
     @NotNull


### PR DESCRIPTION
老哥，前段时间一直比较忙，没来得及看你之前的修改，我又重新梳理的一下在pom里面查找变量的流程

1. 根据`@qwe@`, 在pom中找qwe这个变量
2. 根据变量在pom里面现在找`properties`, 如果无法匹配，再从根节点开始，找不到，返回变量本身
3. 找到了判断是否还是包含变量，如果有对每一个变量做一次2步骤，递归
4. 返回替换后的值

你之前实现的流程和我想的大体一致，但是有一些问题，比如：
```xml
<project>
  <properties>
    <java.version>1.8</java.version>
  </properties>
  <build>
    <first>
      <finalName>
        test
      </finalName>
    </first>
  </build>
</project>
```
我直接配置`@project.build.first.finalName@`, 没有使用`properties`的值，因为没有`${` 这个记号, 就会导致后面都无法匹配。
而且，在匹配不是`properties`的值的流程中，你的代码:
```java
String elementName = nameItem.substring(
                    nameItem.indexOf("{") + 1,
                    nameItem.indexOf("}")
            );
            if (elementName.toLowerCase().startsWith("project.")) {
                elementName = elementName.substring(elementName.indexOf(".") + 1);
            }
            Element itemElement = element.element(elementName);
```
会有这么个问题，比如在匹配`${project.build.first.finalName}`的时候，`elementName`这时候是`build.first.finalName`, 而`element.element("build.first.finalName")`是null的，这也是你之前问我为什么我要用到循环来`element.element`的原因。
因为需要分割`.`来一步一步的element才能拿到那个节点。