### PR TITLE
[future] Http tools增加连接超时和读取超时参数

### DIFF
--- a/src/main/java/com/github/restful/tool/beans/settings/Settings.java
+++ b/src/main/java/com/github/restful/tool/beans/settings/Settings.java
@@ -251,6 +251,28 @@ public class Settings {
                 }
         );
 
+        public static final SettingKey<Integer> CONNECTION_TIMEOUT = SettingKey.createInputNumber(
+                Bundle.getString("setting.httpTools.DefaultConnectionTimeout"),
+                3,
+                data -> {
+                    if (data == null) {
+                        return false;
+                    }
+                    return true;
+                }
+        );
+
+        public static final SettingKey<Integer> READ_TIMEOUT = SettingKey.createInputNumber(
+                Bundle.getString("setting.httpTools.DefaultReadTimeout"),
+                60,
+                data -> {
+                    if (data == null) {
+                        return false;
+                    }
+                    return true;
+                }
+        );
+
         public HttpToolOptionForm() {
             super(Bundle.getString("setting.httpTools"), 2);
         }

--- a/src/main/java/com/github/restful/tool/view/window/frame/RestDetail.java
+++ b/src/main/java/com/github/restful/tool/view/window/frame/RestDetail.java
@@ -60,7 +60,6 @@ import java.util.regex.Pattern;
 public class RestDetail extends JPanel {
 
     public static final FileType DEFAULT_FILE_TYPE = JsonEditor.TEXT_FILE_TYPE;
-    private static final int REQUEST_TIMEOUT = 1000 * 10;
     private static final String IDENTITY_HEAD = "HEAD";
     private static final String IDENTITY_BODY = "BODY";
     private final Project project;
@@ -386,7 +385,10 @@ public class RestDetail extends JPanel {
     }
 
     private HttpRequest getHttpRequest(@NotNull HttpMethod method, @NotNull String url, String head, String body) {
-        HttpRequest request = HttpUtil.createRequest(Method.valueOf(method.name()), url).timeout(REQUEST_TIMEOUT);
+
+        HttpRequest request = HttpUtil.createRequest(Method.valueOf(method.name()), url)
+                .setConnectionTimeout(Settings.HttpToolOptionForm.CONNECTION_TIMEOUT.getData() * 1000)
+                .setReadTimeout(Settings.HttpToolOptionForm.READ_TIMEOUT.getData() * 1000);
         if (head != null && !"".equals(head.trim())) {
             convert.formatMap(head).forEach((s, o) -> request.header(s, (String) o));
         }

--- a/src/main/resources/messages/RestfulToolBundle.properties
+++ b/src/main/resources/messages/RestfulToolBundle.properties
@@ -42,6 +42,8 @@ setting.httpTools.TheMaximumNumberOfRedirectsAllowed=The maximum number of redir
 setting.httpTools.DefaultContentType=Select the default Content-Type
 setting.httpTools.DefaultContextPathOfTheContainer=Select the default Context Path of the container(Must start with'/' and cannot end with'/')
 setting.httpTools.DefaultPortOfTheContainer=Select the default port of the container(0-65535)
+setting.httpTools.DefaultConnectionTimeout=Set the request connectionTimeout(3s)
+setting.httpTools.DefaultReadTimeout=Set the request readTimeout(30s)
 
 ## Notify
 notify.error.class.def.notfound=IDE is missing the corresponding package file: {0}

--- a/src/main/resources/messages/RestfulToolBundle_zh.properties
+++ b/src/main/resources/messages/RestfulToolBundle_zh.properties
@@ -42,6 +42,8 @@ setting.httpTools.TheMaximumNumberOfRedirectsAllowed=HTTP\u7684\u6700\u5927\u91C
 setting.httpTools.DefaultContentType=\u9009\u62E9\u9ED8\u8BA4\u7684Content-Type
 setting.httpTools.DefaultContextPathOfTheContainer=\u9009\u62E9\u5BB9\u5668\u9ED8\u8BA4\u7684Context Path\uFF08\u5FC5\u987B\u4EE5'/'\u5F00\u5934\u4E14\u4E0D\u80FD\u4EE5'/'\u7ED3\u5C3E\uFF09
 setting.httpTools.DefaultPortOfTheContainer=\u9009\u62E9\u5BB9\u5668\u9ED8\u8BA4\u7684\u7AEF\u53E3\u53F7\uFF080-65535\uFF09
+setting.httpTools.DefaultConnectionTimeout=\u8BBE\u7F6E\u8BF7\u6C42\u7684\u8FDE\u63A5\u8D85\u65F6\u65F6\u95F4(3\u79D2)
+setting.httpTools.DefaultReadTimeout=\u8BBE\u7F6E\u8BF7\u6C42\u7684\u8BFB\u53D6\u8D85\u65F6\u65F6\u95F4(30\u79D2)
 
 ## Notify
 notify.error.class.def.notfound=IDE\u7F3A\u5C11\u76F8\u5E94\u7684\u8F6F\u4EF6\u5305\u6587\u4EF6\uFF1A{0}


### PR DESCRIPTION
原有请求超时设置的是10s，包含**连接超时(ConnectionTimeout)**和**读取超时(ReadTimeout)**，且无法修改。

根据个人实践，在设置中增加这两项配置:**ConnectionTimeout 3s**，**ReadTimeout 30s**

[截图](https://github.com/fishandsheep/fishandsheep/blob/main/http.png)